### PR TITLE
codecov: Ignore cmd/ directory

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,6 @@ comment:
   hide_project_coverage: false
   branches:
     - "main"
+
+ignore:
+  - "cmd/" # Ignore trivial wrapper commands


### PR DESCRIPTION
The commands are trivial and should be skipped from coverage testing.